### PR TITLE
Ensure POST requests are UTF-8 encoded

### DIFF
--- a/SheerID.php
+++ b/SheerID.php
@@ -278,6 +278,9 @@ class SheerIDRequest {
 		if ("POST" === $this->method){
 			curl_setopt($ch, CURLOPT_POST, TRUE);
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $query);
+			curl_setopt($ch, CURLOPT_HTTPHEADER, array_merge($this->headers, array(
+				'Content-type: application/x-www-form-urlencoded; charset=utf-8',
+			)));
 			
 			if ($this->verbose) {
 				error_log("[SheerID] POST $url $query");


### PR DESCRIPTION
We're running into 400 bad request responses when we attempt to verify individuals with "special" characters (e.g. `Test Härkönen`)

We can resolve the errors by explicitly specifying a UTF-8 charset on verification requests (and all requests with body content).